### PR TITLE
Update project name to follow "git remote ..." syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "git-open-remote"
+name = "git-remote-open"
 version = "0.1.0"
 dependencies = [
  "assert_cmd 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-name = "git-open-remote"
+name = "git-remote-open"
 version = "0.1.0"
 authors = ["Jonathan Knapp <jon@coffeeandcode.com>"]
-homepage = "https://github.com/CoffeeAndCode/git-open-remote"
+homepage = "https://github.com/CoffeeAndCode/git-remote-open"
 description = "Cli helper to quickly open git remote origin url in a browser"
-repository = "https://github.com/CoffeeAndCode/git-open-remote"
-documentation = "https://github.com/CoffeeAndCode/git-open-remote"
+repository = "https://github.com/CoffeeAndCode/git-remote-open"
+documentation = "https://github.com/CoffeeAndCode/git-remote-open"
 readme = "README.md"
 license = "MIT"
 
 [badges]
-travis-ci = { repository = "CoffeeAndCode/git-open-remote" }
+travis-ci = { repository = "CoffeeAndCode/git-remote-open" }
 
 [features]
 fail-on-warnings = []

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# git-open-remote
+# git-remote-open
 
 [![Build Status](https://travis-ci.org/CoffeeAndCode/git-remote-open.svg?branch=master)](https://travis-ci.org/CoffeeAndCode/git-remote-open)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-extern crate git_open_remote;
+extern crate git_remote_open;
 extern crate open;
 
 use std::env;
@@ -10,7 +10,7 @@ fn open_file(file_path: &str) -> Result<ExitStatus, std::io::Error> {
 }
 
 fn main() {
-    if !git_open_remote::git_exists() {
+    if !git_remote_open::git_exists() {
         eprintln!("Unable to find git on your system.");
         exit(1);
     }


### PR DESCRIPTION
This fixes the invalid Travis badge url in the readme as well.