### PR TITLE
Add a lint script, update the README, add base CHANGELOG file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- initial cli tool
+- CI config for Travis
+- `bin/lint` script for project cleanliness
+
+[unreleased]: https://github.com/CoffeeAndCode/git-remote-open/compare/6d4942b...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/CoffeeAndCode/git-remote-open"
 documentation = "https://github.com/CoffeeAndCode/git-remote-open"
 readme = "README.md"
 license = "MIT"
+publish = false
 
 [badges]
 travis-ci = { repository = "CoffeeAndCode/git-remote-open" }

--- a/README.md
+++ b/README.md
@@ -2,4 +2,27 @@
 
 [![Build Status](https://travis-ci.org/CoffeeAndCode/git-remote-open.svg?branch=master)](https://travis-ci.org/CoffeeAndCode/git-remote-open)
 
-CLI helper to quickly open git remote origin url in a browser.
+CLI helper to quickly open git remote origin url in a browser. Run
+`git-remote-open` from a `git` directory to open the `origin` remote's url in
+your default browser.
+
+You can also pass in the directory you'd like to open
+as the first argument like `git-remote-open ../some/other/folder`
+
+This package is not pushed to crates.io, but you can install it directly from
+source by running:
+
+```shell
+cargo install --force git-remote-open --git https://github.com/CoffeeAndCode/git-remote-open
+```
+
+## Development
+
+The project uses [clippy](https://github.com/rust-lang-nursery/rust-clippy) for
+linting. It will also use [rustfmt](https://github.com/rust-lang-nursery/rustfmt)
+to format all Rust files.
+
+You can run `bin/lint` with a recent version of Rust to run the same checks the
+CI server will run.
+
+Run `cargo test` to run the project's unit and integration tests.

--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+set -x
+
+rustup component add clippy-preview
+cargo clippy --all -- -D clippy
+
+rustup component add rustfmt-preview
+cargo fmt --all -- --check
+
+cargo check --all --features=fail-on-warnings


### PR DESCRIPTION
This does a few cleanup items:

- add a CHANGELOG file
- update README with install instructions
- add a lint script that runs the same checks as the CI server